### PR TITLE
split loading and parsing in separate methods so a string may be loaded as gpx data

### DIFF
--- a/src/phpGPX/phpGPX.php
+++ b/src/phpGPX/phpGPX.php
@@ -59,7 +59,20 @@ class phpGPX
 	 */
 	public static function load($path)
 	{
-		$xml = simplexml_load_file($path);
+		$xml = file_get_contents($path);
+
+		return self::parse($xml);		
+	}
+
+	/**
+	 * @param $xml
+	 * @return GpxFile
+	 */
+
+	public function parse($xml) 
+	{
+		$xml = simplexml_load_string($xml);
+
 		$gpx = new GpxFile();
 
 		// Parse creator

--- a/src/phpGPX/phpGPX.php
+++ b/src/phpGPX/phpGPX.php
@@ -69,7 +69,7 @@ class phpGPX
 	 * @return GpxFile
 	 */
 
-	public function parse($xml) 
+	public static function parse($xml) 
 	{
 		$xml = simplexml_load_string($xml);
 


### PR DESCRIPTION
implements #8 