### PR TITLE
Bugfix for cumulative elevation gain

### DIFF
--- a/src/phpGPX/Models/Route.php
+++ b/src/phpGPX/Models/Route.php
@@ -109,13 +109,15 @@ class Route extends Collection
 			$this->stats->distance += $this->points[$p]->difference;
 			$this->points[$p]->distance = $this->stats->distance;
 
-			if ($this->stats->cumulativeElevationGain === null) {
-				$lastElevation = $firstPoint->elevation;
-				$this->stats->cumulativeElevationGain = 0;
-			} else {
-				$elevationDelta = $this->points[$p]->elevation - $lastElevation;
-				$this->stats->cumulativeElevationGain += ($elevationDelta > 0) ? $elevationDelta : 0;
-				$lastElevation = $this->points[$p]->elevation;
+			if ($this->points[$p]->elevation !== null) {
+				if ($this->stats->cumulativeElevationGain === null) {
+					$lastElevation = $this->points[$p]->elevation;
+					$this->stats->cumulativeElevationGain = 0;
+				} else {
+					$elevationDelta = $this->points[$p]->elevation - $lastElevation;
+					$this->stats->cumulativeElevationGain += ($elevationDelta > 0) ? $elevationDelta : 0;
+					$lastElevation = $this->points[$p]->elevation;
+				}
 			}
 
 			if ($this->stats->minAltitude === null) {

--- a/src/phpGPX/Models/Track.php
+++ b/src/phpGPX/Models/Track.php
@@ -115,13 +115,15 @@ class Track extends Collection
 				$this->stats->distance += $this->segments[$s]->points[$p]->difference;
 				$this->segments[$s]->points[$p]->distance = $this->stats->distance;
 
-				if ($this->stats->cumulativeElevationGain === null) {
-					$lastElevation = $firstPoint->elevation;
-					$this->stats->cumulativeElevationGain = 0;
-				} else {
-					$elevationDelta = $this->segments[$s]->points[$p]->elevation - $lastElevation;
-					$this->stats->cumulativeElevationGain += ($elevationDelta > 0) ? $elevationDelta : 0;
-					$lastElevation = $this->segments[$s]->points[$p]->elevation;
+				if ($this->segments[$s]->points[$p]->elevation !== null) {
+					if ($this->stats->cumulativeElevationGain === null) {
+						$lastElevation = $this->segments[$s]->points[$p]->elevation;
+						$this->stats->cumulativeElevationGain = 0;
+					} else {
+						$elevationDelta = $this->segments[$s]->points[$p]->elevation - $lastElevation;
+						$this->stats->cumulativeElevationGain += ($elevationDelta > 0) ? $elevationDelta : 0;
+						$lastElevation = $this->segments[$s]->points[$p]->elevation;
+					}
 				}
 			}
 			if ($this->stats->minAltitude === null) {


### PR DESCRIPTION
Fixed a bug with stats calculation. If the first point in the segment
had an elevation of null, that would cause the elevation gain to
increase from NULL (or zero) to the next point's elevation. Added a
check to see, whether there is elevation data in the point and only then
add it.