### PR TITLE
custom creator attribute

### DIFF
--- a/src/phpGPX/Models/GpxFile.php
+++ b/src/phpGPX/Models/GpxFile.php
@@ -106,7 +106,7 @@ class GpxFile implements Summarizable
 
 		$gpx = $document->createElementNS("http://www.topografix.com/GPX/1/1", "gpx");
 		$gpx->setAttribute("version", "1.1");
-		$gpx->setAttribute("creator", phpGPX::getSignature());
+		$gpx->setAttribute("creator", $this->creator ? $this->creator : phpGPX::getSignature());
 
 		ExtensionParser::$usedNamespaces = [];
 


### PR DESCRIPTION
"phpGPX\Models\GpxFile" class can set 'creator' attribute but not affect. Now make a judgement if creator is null use "phpGPX::getSignature()".