### PR TITLE
ignore track points with 0 elevation for minHeight calculation

### DIFF
--- a/src/phpGPX/Models/Segment.php
+++ b/src/phpGPX/Models/Segment.php
@@ -92,7 +92,9 @@ class Segment implements Summarizable, StatsCalculator
 				$this->stats->maxAltitude = $this->points[$i]->elevation;
 			}
 
-			if ($this->stats->minAltitude > $this->points[$i]->elevation) {
+			// some tools generate track points with an elevation of 0 -- this is usually an error
+            // we don't use this points in the minAltitude calculation
+			if ($this->points[$i]->elevation > 0 && $this->stats->minAltitude > $this->points[$i]->elevation) {
 				$this->stats->minAltitude = $this->points[$i]->elevation;
 			}
 		}


### PR DESCRIPTION
My Suunto watch sometimes creates a trackpoint without gpx extensions and with an elevation of 0. This error affects the minHeight stats calculation. 

In 99.99% an elevation of 0 is wrong, except on the ocean (and even there we're usually on a boat with an elevation of 1 meters+). I think it's safe to just ignore a 0 elevation for the stats calc.