### PR TITLE
Skip empty track segments in GPX

### DIFF
--- a/src/phpGPX/Parsers/SegmentParser.php
+++ b/src/phpGPX/Parsers/SegmentParser.php
@@ -28,6 +28,10 @@ abstract class SegmentParser
 		foreach ($nodes as $node) {
 			$segment = new Segment();
 
+			if (!$node->count()) {
+			    continue;
+            }
+
 			if (isset($node->trkpt)) {
 				$segment->points = [];
 

--- a/tests/fixtures/gps-track.gpx
+++ b/tests/fixtures/gps-track.gpx
@@ -24,5 +24,6 @@
         <time>2017-08-13T07:12:18.000Z</time>
       </trkpt>
     </trkseg>
+    <trkseg/>
   </trk>
 </gpx>


### PR DESCRIPTION
Endomondo sometimes export empty track segments. This will handle cases when empty segments may exist.