### PR TITLE
Limiting maximum elevation difference to protect from spikes

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ public static $IGNORE_ELEVATION_0 = true;
 
 /**
  * Apply elevation gain/loss smoothing? If true, the threshold in
- * ELEVATION_SMOOTHING_THRESHOLD applies
+ * ELEVATION_SMOOTHING_THRESHOLD and ELEVATION_SMOOTHING_SPIKES_THRESHOLD (if not null) applies
  */
 public static $APPLY_ELEVATION_SMOOTHING = false;
 
@@ -255,6 +255,12 @@ public static $APPLY_ELEVATION_SMOOTHING = false;
  * the minimum elevation difference between considered points in meters
  */
 public static $ELEVATION_SMOOTHING_THRESHOLD = 2;
+
+/**
+ * if APPLY_ELEVATION_SMOOTHING is true
+ * the maximum elevation difference between considered points in meters
+ */
+public static $ELEVATION_SMOOTHING_SPIKES_THRESHOLD = null;
 
 /**
  * Apply distance calculation smoothing? If true, the threshold in

--- a/src/phpGPX/Helpers/ElevationGainLossCalculator.php
+++ b/src/phpGPX/Helpers/ElevationGainLossCalculator.php
@@ -50,7 +50,8 @@ class ElevationGainLossCalculator
 
 			// if smoothing is applied we only consider points with a delta above the threshold (e.g. 2 meters)
 			if (phpGPX::$APPLY_ELEVATION_SMOOTHING &&
-				abs($elevationDelta) > phpGPX::$ELEVATION_SMOOTHING_THRESHOLD) {
+				abs($elevationDelta) > phpGPX::$ELEVATION_SMOOTHING_THRESHOLD &&
+                		(phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD === null || abs($elevationDelta) < phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD)) {
 				$cumulativeElevationGain += ($elevationDelta > 0) ? $elevationDelta : 0;
 				$cumulativeElevationLoss += ($elevationDelta < 0) ? abs($elevationDelta) : 0;
 

--- a/src/phpGPX/Helpers/ElevationGainLossCalculator.php
+++ b/src/phpGPX/Helpers/ElevationGainLossCalculator.php
@@ -51,7 +51,7 @@ class ElevationGainLossCalculator
 			// if smoothing is applied we only consider points with a delta above the threshold (e.g. 2 meters)
 			if (phpGPX::$APPLY_ELEVATION_SMOOTHING &&
 				abs($elevationDelta) > phpGPX::$ELEVATION_SMOOTHING_THRESHOLD &&
-                		(phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD === null || abs($elevationDelta) < phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD)) {
+						(phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD === null || abs($elevationDelta) < phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD)) {
 				$cumulativeElevationGain += ($elevationDelta > 0) ? $elevationDelta : 0;
 				$cumulativeElevationLoss += ($elevationDelta < 0) ? abs($elevationDelta) : 0;
 

--- a/src/phpGPX/Helpers/SerializationHelper.php
+++ b/src/phpGPX/Helpers/SerializationHelper.php
@@ -66,20 +66,20 @@ abstract class SerializationHelper
 		}
 	}
 
-    public static function filterNotNull(array $array)
-    {
-        foreach ($array as &$item) {
-            if (!is_array($item)) {
-                continue;
-            }
-            
-            $item = self::filterNotNull($item);
-        }
+	public static function filterNotNull(array $array)
+	{
+		foreach ($array as &$item) {
+			if (!is_array($item)) {
+				continue;
+			}
+			
+			$item = self::filterNotNull($item);
+		}
 
-        $array = array_filter($array, function ($item) {
-            return $item !== null && (!is_array($item) || count($item));
-        });
+		$array = array_filter($array, function ($item) {
+			return $item !== null && (!is_array($item) || count($item));
+		});
 
-        return $array;
-    }
+		return $array;
+	}
 }

--- a/src/phpGPX/Models/GpxFile.php
+++ b/src/phpGPX/Models/GpxFile.php
@@ -55,7 +55,7 @@ class GpxFile implements Summarizable
 	 * Creator of GPX file.
 	 * @var string|null
 	 */
-		public $creator;
+	public $creator;
 
 	/**
 	 * GpxFile constructor.

--- a/src/phpGPX/Parsers/ExtensionParser.php
+++ b/src/phpGPX/Parsers/ExtensionParser.php
@@ -41,7 +41,6 @@ abstract class ExtensionParser
 					break;
 				default:
 					foreach ($nodes->children($namespace) as $child_key => $value) {
-
 						$extensions->unsupported[$key ? "$key:$child_key" : "$child_key"] = (string) $value;
 					}
 			}

--- a/src/phpGPX/Parsers/PersonParser.php
+++ b/src/phpGPX/Parsers/PersonParser.php
@@ -46,8 +46,7 @@ abstract class PersonParser
 		}
 
 		# TODO: is_iterable
-		if (!is_null($person->links))
-		{
+		if (!is_null($person->links)) {
 			foreach ($person->links as $link) {
 				$child = LinkParser::toXML($link, $document);
 				$node->appendChild($child);

--- a/src/phpGPX/Parsers/SegmentParser.php
+++ b/src/phpGPX/Parsers/SegmentParser.php
@@ -29,8 +29,8 @@ abstract class SegmentParser
 			$segment = new Segment();
 
 			if (!$node->count()) {
-			    continue;
-            }
+				continue;
+			}
 
 			if (isset($node->trkpt)) {
 				$segment->points = [];

--- a/src/phpGPX/phpGPX.php
+++ b/src/phpGPX/phpGPX.php
@@ -78,6 +78,13 @@ class phpGPX
 	 */
 	public static $ELEVATION_SMOOTHING_THRESHOLD = 2;
 
+    	/**
+     	 * if APPLY_ELEVATION_SMOOTHING is true
+     	 * the maximum elevation difference between considered points in meters
+     	 * @var int|null
+     	*/
+    	public static $ELEVATION_SMOOTHING_SPIKES_THRESHOLD = null;
+	
 	/**
 	 * Apply distance calculation smoothing? If true, the threshold in
 	 * DISTANCE_SMOOTHING_THRESHOLD applies

--- a/src/phpGPX/phpGPX.php
+++ b/src/phpGPX/phpGPX.php
@@ -66,7 +66,7 @@ class phpGPX
 
 	/**
 	 * Apply elevation gain/loss smoothing? If true, the threshold in
-	 * ELEVATION_SMOOTHING_THRESHOLD applies
+	 * ELEVATION_SMOOTHING_THRESHOLD and ELEVATION_SMOOTHING_SPIKES_THRESHOLD (if not null) applies
 	 * @var bool
 	 */
 	public static $APPLY_ELEVATION_SMOOTHING = false;
@@ -78,13 +78,13 @@ class phpGPX
 	 */
 	public static $ELEVATION_SMOOTHING_THRESHOLD = 2;
 
-    	/**
-     	 * if APPLY_ELEVATION_SMOOTHING is true
-     	 * the maximum elevation difference between considered points in meters
-     	 * @var int|null
-     	*/
-    	public static $ELEVATION_SMOOTHING_SPIKES_THRESHOLD = null;
-	
+	/**
+	 * if APPLY_ELEVATION_SMOOTHING is true
+	 * the maximum elevation difference between considered points in meters
+	 * @var int|null
+	 */
+	public static $ELEVATION_SMOOTHING_SPIKES_THRESHOLD = null;
+
 	/**
 	 * Apply distance calculation smoothing? If true, the threshold in
 	 * DISTANCE_SMOOTHING_THRESHOLD applies

--- a/tests/UnitTests/phpGPX/Helpers/SerializationHelperTest.php
+++ b/tests/UnitTests/phpGPX/Helpers/SerializationHelperTest.php
@@ -10,84 +10,84 @@ use PHPUnit\Framework\TestCase;
 
 class SerializationHelperTest extends TestCase
 {
-    public function testIntegerOrNull()
-    {
-        $this->assertNull(SerializationHelper::integerOrNull(""));
-        $this->assertNull(SerializationHelper::integerOrNull(null));
-        $this->assertNull(SerializationHelper::integerOrNull("BLA"));
-        $this->assertInternalType("int", SerializationHelper::integerOrNull(5));
-        $this->assertInternalType("int", SerializationHelper::integerOrNull("5"));
-    }
+	public function testIntegerOrNull()
+	{
+		$this->assertNull(SerializationHelper::integerOrNull(""));
+		$this->assertNull(SerializationHelper::integerOrNull(null));
+		$this->assertNull(SerializationHelper::integerOrNull("BLA"));
+		$this->assertInternalType("int", SerializationHelper::integerOrNull(5));
+		$this->assertInternalType("int", SerializationHelper::integerOrNull("5"));
+	}
 
-    public function testFloatOrNull()
-    {
-        $this->assertNull(SerializationHelper::floatOrNull(""));
-        $this->assertNull(SerializationHelper::floatOrNull(null));
-        $this->assertNull(SerializationHelper::floatOrNull("BLA"));
-        $this->assertInternalType("float", SerializationHelper::floatOrNull(5.6));
-        $this->assertInternalType("float", SerializationHelper::floatOrNull(5));
-        $this->assertInternalType("float", SerializationHelper::floatOrNull("5.6"));
-        $this->assertInternalType("float", SerializationHelper::floatOrNull("5"));
-    }
+	public function testFloatOrNull()
+	{
+		$this->assertNull(SerializationHelper::floatOrNull(""));
+		$this->assertNull(SerializationHelper::floatOrNull(null));
+		$this->assertNull(SerializationHelper::floatOrNull("BLA"));
+		$this->assertInternalType("float", SerializationHelper::floatOrNull(5.6));
+		$this->assertInternalType("float", SerializationHelper::floatOrNull(5));
+		$this->assertInternalType("float", SerializationHelper::floatOrNull("5.6"));
+		$this->assertInternalType("float", SerializationHelper::floatOrNull("5"));
+	}
 
-    public function testStringOrNull()
-    {
-        $this->assertNull(SerializationHelper::stringOrNull(null));
-        $this->assertInternalType("string", SerializationHelper::stringOrNull(""));
-        $this->assertInternalType("string", SerializationHelper::stringOrNull("Bla bla"));
-    }
+	public function testStringOrNull()
+	{
+		$this->assertNull(SerializationHelper::stringOrNull(null));
+		$this->assertInternalType("string", SerializationHelper::stringOrNull(""));
+		$this->assertInternalType("string", SerializationHelper::stringOrNull("Bla bla"));
+	}
 
-    /**
-     * @dataProvider dataProviderFilterNotNull
-     */
-    public function testFilterNotNull($expected, $actual)
-    {
-        $this->assertEquals($expected, SerializationHelper::filterNotNull($actual));
-    }
+	/**
+	 * @dataProvider dataProviderFilterNotNull
+	 */
+	public function testFilterNotNull($expected, $actual)
+	{
+		$this->assertEquals($expected, SerializationHelper::filterNotNull($actual));
+	}
 
-    public function dataProviderFilterNotNull()
-    {
-        return [
-            'numeric 1' => [
-                [],
-                [null],
-            ],
-            'numeric 2' => [
-                [],
-                [null, [null]],
-            ],
-            'numeric 3' => [
-                [1 => 1],
-                [null, 1],
-            ],
-            'numeric 4' => [
-                [1 => 1, 3 => 2],
-                [null, 1, null, 2, null],
-            ],
-            'numeric 5' => [
-                [1 => 1, 3 => 2, 5 => [0 => 3, 2 => 4], 6 => 5],
-                [null, 1, null, 2, null, [3, null, 4], 5, null],
-            ],
-            'associative 1' => [
-                [],
-                ["foo" => null],
-            ],
-            'associative 2' => [
-                [],
-                ["foo" => null, ["bar" => null]],
-            ],
-            'associative 3' => [
-                ["bar" => 1],
-                ["foo" => null, "bar" => 1],
-            ],
-            'associative 4' => [
-                ["bar" => 1, "caw" => 2],
-                ["foo" => null, "bar" => 1, "baz" => null, "caw" => 2, "doo" => null],
-            ],
-            'associative 5' => [
-                ["bar" => 1, "caw" => 2, "ere" => ["foo" => 3, "baz" => 4], "moo" => 5],
-                ["foo" => null, "bar" => 1, "baz" => null, "caw" => 2, "doo" => null, "ere" => ["foo" => 3, "bar" => null, "baz" => 4], "moo" => 5, "boo" => null],
-            ],
-        ];
-    }
+	public function dataProviderFilterNotNull()
+	{
+		return [
+			'numeric 1' => [
+				[],
+				[null],
+			],
+			'numeric 2' => [
+				[],
+				[null, [null]],
+			],
+			'numeric 3' => [
+				[1 => 1],
+				[null, 1],
+			],
+			'numeric 4' => [
+				[1 => 1, 3 => 2],
+				[null, 1, null, 2, null],
+			],
+			'numeric 5' => [
+				[1 => 1, 3 => 2, 5 => [0 => 3, 2 => 4], 6 => 5],
+				[null, 1, null, 2, null, [3, null, 4], 5, null],
+			],
+			'associative 1' => [
+				[],
+				["foo" => null],
+			],
+			'associative 2' => [
+				[],
+				["foo" => null, ["bar" => null]],
+			],
+			'associative 3' => [
+				["bar" => 1],
+				["foo" => null, "bar" => 1],
+			],
+			'associative 4' => [
+				["bar" => 1, "caw" => 2],
+				["foo" => null, "bar" => 1, "baz" => null, "caw" => 2, "doo" => null],
+			],
+			'associative 5' => [
+				["bar" => 1, "caw" => 2, "ere" => ["foo" => 3, "baz" => 4], "moo" => 5],
+				["foo" => null, "bar" => 1, "baz" => null, "caw" => 2, "doo" => null, "ere" => ["foo" => 3, "bar" => null, "baz" => 4], "moo" => 5, "boo" => null],
+			],
+		];
+	}
 }


### PR DESCRIPTION
Due to some inaccurate elevation gain/loss data I found there's a plenty of GPX files from mobiles/watches with spikes in elevation (usually 100m> change).
This small adjustment checks if elevation delta is greater then allowed value in `phpGPX::$ELEVATION_SMOOTHING_SPIKES_THRESHOLD` to avoid spikes.