### PR TITLE
do SORT_BY_TIMESTAMP only for tracks with timestamps

### DIFF
--- a/src/phpGPX/Models/Route.php
+++ b/src/phpGPX/Models/Route.php
@@ -47,7 +47,7 @@ class Route extends Collection
 
 		$points = array_merge($points, $this->points);
 
-		if (phpGPX::$SORT_BY_TIMESTAMP && !empty($points)) {
+		if (phpGPX::$SORT_BY_TIMESTAMP && !empty($points) && $points[0]->time !== null) {
 			usort($points, array('phpGPX\Helpers\DateTimeHelper', 'comparePointsByTimestamp'));
 		}
 

--- a/src/phpGPX/Models/Track.php
+++ b/src/phpGPX/Models/Track.php
@@ -46,7 +46,7 @@ class Track extends Collection
 			$points = array_merge($points, $segment->points);
 		}
 
-		if (phpGPX::$SORT_BY_TIMESTAMP && !empty($points)) {
+		if (phpGPX::$SORT_BY_TIMESTAMP && !empty($points) && $points[0]->time !== null) {
 			usort($points, array('phpGPX\Helpers\DateTimeHelper', 'comparePointsByTimestamp'));
 		}
 


### PR DESCRIPTION
There are GPX tracks with all data except timestamps, e.g. when users create GPX files in a planning tool.

Currently, analyzing these tracks crashes if the SORT_BY_TIMESTAMP option is set (actually, there seem to be tools outside that do not pre-sort the points by timestamp). 

This merge request checks if the first point has a timestamp. If not, the sorting is not done.
