### PR TITLE
Disable fail-fast in PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
         php-version: ['7.3', '8.0', '8.1']


### PR DESCRIPTION
So we can see which/if all versions are failing rather than just the first one that fails.